### PR TITLE
Make body parsing lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MayaJS
 
+#### started this project in 10th August 2024
 **MayaJS** is a simple and lightweight HTTP server library for Node.js, designed to give you control over your API routes and middleware in an intuitive and efficient way. With MayaJS, you can quickly set up a server, define routes, and optimize important routes for faster response times.
 
 ## Features

--- a/src/context.js
+++ b/src/context.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const fs = require("fs");
+const { parseRequestBody } = require("./requestParser.js");
 const CACHE_TTL = 1 * 60 * 1000;
 const MAX_CACHE_SIZE = 100;
 const cache = new Map();
@@ -65,6 +66,7 @@ module.exports = function createContext(
     _parsedCookie: null,
     _parsedQuery : null,
     _parsedParams: null,
+    _parsedBody: null,
     next: () => {},
     //
 
@@ -73,8 +75,11 @@ module.exports = function createContext(
       return this;
     },
 
-    body(){
-      return  request.body ?? {}
+    async body() {
+      if (!this._parsedBody) {
+        this._parsedBody = await parseRequestBody(request.rawBody ?? Buffer.alloc(0), request.headers);
+      }
+      return this._parsedBody;
     },
 
     setHeader(key, value) {
@@ -267,7 +272,7 @@ module.exports = function createContext(
         if (queryString) {
           const query = new URLSearchParams(queryString);
           this._parsedQuery = Object.fromEntries(query.entries());
-        } 
+        }
         else return null;
       }
       return queryKey ? this._parsedQuery[queryKey] || null : this._parsedQuery;
@@ -285,7 +290,7 @@ module.exports = function createContext(
 
 function parseCookie(header){
   const cookies = {}
- 
+
   const cookieArray = header.split(";")
   cookieArray.forEach(cookie =>{
     const [cookieName,cookievalue] = cookie.trim().split("=")

--- a/src/handleSocketConnection.js
+++ b/src/handleSocketConnection.js
@@ -2,7 +2,7 @@ const handleRequest = require("./requestHandler.js");
 const ErrorHandler = require("./errResponse.js");
 const { Buffer } = require("buffer");
 const Cache = require("./cache.js");
-const { parseRequestBody, parseRequestHeader } = require("./requestParser.js");
+const { parseRequestHeader } = require("./requestParser.js");
 // const { cc } = require("bun:ffi");
 // const { join } = require("path");
 
@@ -25,8 +25,9 @@ const cache = new Cache();
 module.exports = async function handleConnection(socket, maya) {
   let buffer = Buffer.alloc(0);
   let parsedHeader;
+
+  
   socket.on("data", async (chunk) => {
-    // const startTime = Date.now();
     buffer = Buffer.concat([buffer, chunk]);
     await processBuffer();
   });
@@ -76,16 +77,8 @@ module.exports = async function handleConnection(socket, maya) {
     );
     if (buffer.length >= contentLength) {
       const bodyBuffer = buffer.slice(0, contentLength); // Extract the body based on content-length
-      const parsedBody = await parseRequestBody(
-        bodyBuffer,
-        parsedHeader?.headers
-      );
 
-      if (parsedBody?.error) {
-        return parsedRequestError(socket, parsedBody.error);
-      }
-
-      const finalResult = { ...parsedHeader, ...parsedBody };
+      const finalResult = { ...parsedHeader, rawBody: bodyBuffer };
       const result = await handleRequest(finalResult, maya);
       if (result) {
         socket.write(result);


### PR DESCRIPTION
Closes #46

## What

Body parsing (JSON / urlencoded / multipart) was happening eagerly for every non-GET request, even when the handler never reads the body. This makes it lazy.

## How

- `handleSocketConnection.js`: still waits for the full `content-length` bytes (needed since it's a stream), but no longer calls `parseRequestBody`. It just attaches the raw buffer (`rawBody`) and calls the handler right away, same as the GET path.
- `context.js`: `ctx.body()` is now `async`, parses `rawBody` on first call only, and caches the result for later calls on the same request.

## Breaking change

`ctx.body()` must now be awaited: `await ctx.body()`.